### PR TITLE
Fix SSE/SSE2 mix up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved performance for `ResamplerFft` when using pure factor 2 configurations.
 - Improved performance for `ResamplerFft` by using SIMD for the real/complex pre- and post-processing.
 
+### Fixed
+
+- Internally butterflies were marked as x86_64 SSE even thought they used SSE2 functionality. This is now fixed. Since
+  all x86_64 need to support both SSE and SSE2 this is a theoretical problem, but which should be fixed.
+
 ## [0.3.1] - 2025-10-31
 
 ### Changed

--- a/src/fft/butterflies/butterfly2/mod.rs
+++ b/src/fft/butterflies/butterfly2/mod.rs
@@ -58,12 +58,12 @@ pub(crate) fn butterfly_2_dispatch(
 
     #[cfg(all(
         target_arch = "x86_64",
-        target_feature = "sse",
+        target_feature = "sse2",
         not(target_feature = "sse3")
     ))]
     {
         if num_columns >= 2 {
-            return unsafe { sse::butterfly_2_sse(data, stage_twiddles, 0, num_columns) };
+            return unsafe { sse::butterfly_2_sse2(data, stage_twiddles, 0, num_columns) };
         }
     }
 
@@ -133,13 +133,13 @@ pub(crate) fn butterfly_2_dispatch_sse3(
 
 #[cfg(all(target_arch = "x86_64", not(feature = "no_std")))]
 #[inline(always)]
-pub(crate) fn butterfly_2_dispatch_sse(
+pub(crate) fn butterfly_2_dispatch_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     num_columns: usize,
 ) {
     if num_columns >= 2 {
-        return unsafe { sse::butterfly_2_sse(data, stage_twiddles, 0, num_columns) };
+        return unsafe { sse::butterfly_2_sse2(data, stage_twiddles, 0, num_columns) };
     }
 
     butterfly_2_scalar(data, stage_twiddles, 0, num_columns);
@@ -180,17 +180,17 @@ mod tests {
     #[test]
     #[cfg(all(
         target_arch = "x86_64",
-        any(not(feature = "no_std"), target_feature = "sse")
+        any(not(feature = "no_std"), target_feature = "sse2")
     ))]
-    fn test_butterfly_2_sse_vs_scalar() {
+    fn test_butterfly_2_sse2_vs_scalar() {
         test_butterfly_against_scalar(
             |data, twiddles, num_columns| butterfly_2_scalar(data, twiddles, 0, num_columns),
             |data, twiddles, num_columns| unsafe {
-                sse::butterfly_2_sse(data, twiddles, 0, num_columns);
+                sse::butterfly_2_sse2(data, twiddles, 0, num_columns);
             },
             2,
             1,
-            "butterfly_2_sse",
+            "butterfly_2_sse2",
         );
     }
 

--- a/src/fft/butterflies/butterfly2/sse.rs
+++ b/src/fft/butterflies/butterfly2/sse.rs
@@ -1,14 +1,14 @@
-#[cfg(any(not(feature = "no_std"), target_feature = "sse"))]
+#[cfg(any(not(feature = "no_std"), target_feature = "sse2"))]
 use crate::Complex32;
 
-/// Pure SSE implementation: processes 2 columns at once.
+/// Pure SSE2 implementation: processes 2 columns at once.
 #[cfg(any(
     test,
     not(feature = "no_std"),
-    all(target_feature = "sse", not(target_feature = "sse3"))
+    all(target_feature = "sse2", not(target_feature = "sse3"))
 ))]
-#[target_feature(enable = "sse")]
-pub(super) unsafe fn butterfly_2_sse(
+#[target_feature(enable = "sse2")]
+pub(super) unsafe fn butterfly_2_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     start_col: usize,
@@ -52,7 +52,7 @@ pub(super) unsafe fn butterfly_2_sse(
             // Multiply by imaginary parts: [tw.im*d.im, tw.im*d.re, ...]
             let prod_im = _mm_mul_ps(tw_im, d_swap);
 
-            // Emulate SSE3's addsub: [a0-b0, a1+b1, a2-b2, a3+b3]
+            // Emulate SSE3's addsub using SSE2: [a0-b0, a1+b1, a2-b2, a3+b3]
             // We want: [prod_re[0]-prod_im[0], prod_re[1]+prod_im[1], prod_re[2]-prod_im[2], prod_re[3]+prod_im[3]]
             // Create a mask to negate elements at indices 0 and 2 (the real parts)
             // Mask layout: [sign_bit, 0, sign_bit, 0] to flip sign of real parts only

--- a/src/fft/butterflies/butterfly3/mod.rs
+++ b/src/fft/butterflies/butterfly3/mod.rs
@@ -106,12 +106,12 @@ pub(crate) fn butterfly_3_dispatch(
 
     #[cfg(all(
         target_arch = "x86_64",
-        target_feature = "sse",
+        target_feature = "sse2",
         not(target_feature = "sse3")
     ))]
     {
         if num_columns >= 2 {
-            return unsafe { sse::butterfly_3_sse(data, stage_twiddles, 0, num_columns) };
+            return unsafe { sse::butterfly_3_sse2(data, stage_twiddles, 0, num_columns) };
         }
     }
 
@@ -181,13 +181,13 @@ pub(crate) fn butterfly_3_dispatch_sse3(
 
 #[cfg(all(target_arch = "x86_64", not(feature = "no_std")))]
 #[inline(always)]
-pub(crate) fn butterfly_3_dispatch_sse(
+pub(crate) fn butterfly_3_dispatch_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     num_columns: usize,
 ) {
     if num_columns >= 2 {
-        return unsafe { sse::butterfly_3_sse(data, stage_twiddles, 0, num_columns) };
+        return unsafe { sse::butterfly_3_sse2(data, stage_twiddles, 0, num_columns) };
     }
 
     butterfly_3_scalar(data, stage_twiddles, 0, num_columns);
@@ -228,17 +228,17 @@ mod tests {
     #[test]
     #[cfg(all(
         target_arch = "x86_64",
-        any(not(feature = "no_std"), target_feature = "sse")
+        any(not(feature = "no_std"), target_feature = "sse2")
     ))]
-    fn test_butterfly_3_sse_vs_scalar() {
+    fn test_butterfly_3_sse2_vs_scalar() {
         test_butterfly_against_scalar(
             |data, twiddles, num_columns| butterfly_3_scalar(data, twiddles, 0, num_columns),
             |data, twiddles, num_columns| unsafe {
-                sse::butterfly_3_sse(data, twiddles, 0, num_columns);
+                sse::butterfly_3_sse2(data, twiddles, 0, num_columns);
             },
             3,
             2,
-            "butterfly_3_sse",
+            "butterfly_3_sse2",
         );
     }
 

--- a/src/fft/butterflies/butterfly3/sse.rs
+++ b/src/fft/butterflies/butterfly3/sse.rs
@@ -1,14 +1,14 @@
-#[cfg(any(not(feature = "no_std"), target_feature = "sse"))]
+#[cfg(any(not(feature = "no_std"), target_feature = "sse2"))]
 use crate::Complex32;
 
-/// Pure SSE implementation: processes 2 columns at once.
+/// Pure SSE2 implementation: processes 2 columns at once.
 #[cfg(any(
     test,
     not(feature = "no_std"),
-    all(target_feature = "sse", not(target_feature = "sse3"))
+    all(target_feature = "sse2", not(target_feature = "sse3"))
 ))]
-#[target_feature(enable = "sse")]
-pub(super) unsafe fn butterfly_3_sse(
+#[target_feature(enable = "sse2")]
+pub(super) unsafe fn butterfly_3_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     start_col: usize,
@@ -57,7 +57,7 @@ pub(super) unsafe fn butterfly_3_sse(
             let x1_swap = _mm_shuffle_ps(x1, x1, 0b10_11_00_01);
             let prod_im = _mm_mul_ps(w1_im, x1_swap);
 
-            // Emulate addsub for complex multiply.
+            // Emulate SSE3 addsub using SSE2 for complex multiply.
             let neg_mask = _mm_castsi128_ps(_mm_set_epi32(
                 0,
                 0x80000000u32 as i32,

--- a/src/fft/butterflies/butterfly4/mod.rs
+++ b/src/fft/butterflies/butterfly4/mod.rs
@@ -107,12 +107,12 @@ pub(crate) fn butterfly_4_dispatch(
 
     #[cfg(all(
         target_arch = "x86_64",
-        target_feature = "sse",
+        target_feature = "sse2",
         not(target_feature = "sse3")
     ))]
     {
         if num_columns >= 2 {
-            return unsafe { sse::butterfly_4_sse(data, stage_twiddles, 0, num_columns) };
+            return unsafe { sse::butterfly_4_sse2(data, stage_twiddles, 0, num_columns) };
         }
     }
 
@@ -178,13 +178,13 @@ pub(crate) fn butterfly_4_dispatch_sse3(
 
 #[cfg(all(target_arch = "x86_64", not(feature = "no_std")))]
 #[inline(always)]
-pub(crate) fn butterfly_4_dispatch_sse(
+pub(crate) fn butterfly_4_dispatch_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     num_columns: usize,
 ) {
     if num_columns >= 2 {
-        return unsafe { sse::butterfly_4_sse(data, stage_twiddles, 0, num_columns) };
+        return unsafe { sse::butterfly_4_sse2(data, stage_twiddles, 0, num_columns) };
     }
 
     butterfly_4_scalar(data, stage_twiddles, 0, num_columns);
@@ -211,17 +211,17 @@ mod tests {
     #[test]
     #[cfg(all(
         target_arch = "x86_64",
-        any(not(feature = "no_std"), target_feature = "sse")
+        any(not(feature = "no_std"), target_feature = "sse2")
     ))]
-    fn test_butterfly_4_sse_vs_scalar() {
+    fn test_butterfly_4_sse2_vs_scalar() {
         test_butterfly_against_scalar(
             |data, twiddles, num_columns| butterfly_4_scalar(data, twiddles, 0, num_columns),
             |data, twiddles, num_columns| unsafe {
-                sse::butterfly_4_sse(data, twiddles, 0, num_columns);
+                sse::butterfly_4_sse2(data, twiddles, 0, num_columns);
             },
             4,
             3,
-            "butterfly_4_sse",
+            "butterfly_4_sse2",
         );
     }
 

--- a/src/fft/butterflies/butterfly4/sse.rs
+++ b/src/fft/butterflies/butterfly4/sse.rs
@@ -1,14 +1,14 @@
-#[cfg(any(not(feature = "no_std"), target_feature = "sse"))]
+#[cfg(any(not(feature = "no_std"), target_feature = "sse2"))]
 use crate::Complex32;
 
-/// Pure SSE implementation: processes 2 columns at once.
+/// Pure SSE2 implementation: processes 2 columns at once.
 #[cfg(any(
     test,
     not(feature = "no_std"),
-    all(target_feature = "sse", not(target_feature = "sse3"))
+    all(target_feature = "sse2", not(target_feature = "sse3"))
 ))]
-#[target_feature(enable = "sse")]
-pub(super) unsafe fn butterfly_4_sse(
+#[target_feature(enable = "sse2")]
+pub(super) unsafe fn butterfly_4_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     start_col: usize,
@@ -58,7 +58,7 @@ pub(super) unsafe fn butterfly_4_sse(
             let x1_swap = _mm_shuffle_ps(x1, x1, 0b10_11_00_01);
             let prod_im = _mm_mul_ps(w1_im, x1_swap);
 
-            // Emulate addsub for complex multiply.
+            // Emulate SSE3 addsub using SSE2 for complex multiply.
             let neg_mask = _mm_castsi128_ps(_mm_set_epi32(
                 0,
                 0x80000000u32 as i32,

--- a/src/fft/butterflies/butterfly5/mod.rs
+++ b/src/fft/butterflies/butterfly5/mod.rs
@@ -167,12 +167,12 @@ pub(crate) fn butterfly_5_dispatch(
 
     #[cfg(all(
         target_arch = "x86_64",
-        target_feature = "sse",
+        target_feature = "sse2",
         not(target_feature = "sse3")
     ))]
     {
         if num_columns >= 2 {
-            return unsafe { sse::butterfly_5_sse(data, stage_twiddles, 0, num_columns) };
+            return unsafe { sse::butterfly_5_sse2(data, stage_twiddles, 0, num_columns) };
         }
     }
 
@@ -238,13 +238,13 @@ pub(crate) fn butterfly_5_dispatch_sse3(
 
 #[cfg(all(target_arch = "x86_64", not(feature = "no_std")))]
 #[inline(always)]
-pub(crate) fn butterfly_5_dispatch_sse(
+pub(crate) fn butterfly_5_dispatch_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     num_columns: usize,
 ) {
     if num_columns >= 2 {
-        return unsafe { sse::butterfly_5_sse(data, stage_twiddles, 0, num_columns) };
+        return unsafe { sse::butterfly_5_sse2(data, stage_twiddles, 0, num_columns) };
     }
 
     butterfly_5_scalar(data, stage_twiddles, 0, num_columns);
@@ -271,17 +271,17 @@ mod tests {
     #[test]
     #[cfg(all(
         target_arch = "x86_64",
-        any(not(feature = "no_std"), target_feature = "sse")
+        any(not(feature = "no_std"), target_feature = "sse2")
     ))]
-    fn test_butterfly_5_sse_vs_scalar() {
+    fn test_butterfly_5_sse2_vs_scalar() {
         test_butterfly_against_scalar(
             |data, twiddles, num_columns| butterfly_5_scalar(data, twiddles, 0, num_columns),
             |data, twiddles, num_columns| unsafe {
-                sse::butterfly_5_sse(data, twiddles, 0, num_columns);
+                sse::butterfly_5_sse2(data, twiddles, 0, num_columns);
             },
             5,
             4,
-            "butterfly_5_sse",
+            "butterfly_5_sse2",
         );
     }
 

--- a/src/fft/butterflies/butterfly5/sse.rs
+++ b/src/fft/butterflies/butterfly5/sse.rs
@@ -1,14 +1,14 @@
-#[cfg(any(not(feature = "no_std"), target_feature = "sse"))]
+#[cfg(any(not(feature = "no_std"), target_feature = "sse2"))]
 use crate::Complex32;
 
-/// Pure SSE implementation: processes 2 columns at once.
+/// Pure SSE2 implementation: processes 2 columns at once.
 #[cfg(any(
     test,
     not(feature = "no_std"),
-    all(target_feature = "sse", not(target_feature = "sse3"))
+    all(target_feature = "sse2", not(target_feature = "sse3"))
 ))]
-#[target_feature(enable = "sse")]
-pub(super) unsafe fn butterfly_5_sse(
+#[target_feature(enable = "sse2")]
+pub(super) unsafe fn butterfly_5_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     start_col: usize,

--- a/src/fft/butterflies/butterfly7/mod.rs
+++ b/src/fft/butterflies/butterfly7/mod.rs
@@ -301,12 +301,12 @@ pub(crate) fn butterfly_7_dispatch(
 
     #[cfg(all(
         target_arch = "x86_64",
-        target_feature = "sse",
+        target_feature = "sse2",
         not(target_feature = "sse3")
     ))]
     {
         if num_columns >= 2 {
-            return unsafe { sse::butterfly_7_sse(data, stage_twiddles, 0, num_columns) };
+            return unsafe { sse::butterfly_7_sse2(data, stage_twiddles, 0, num_columns) };
         }
     }
 
@@ -372,13 +372,13 @@ pub(crate) fn butterfly_7_dispatch_sse3(
 
 #[cfg(all(target_arch = "x86_64", not(feature = "no_std")))]
 #[inline(always)]
-pub(crate) fn butterfly_7_dispatch_sse(
+pub(crate) fn butterfly_7_dispatch_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     num_columns: usize,
 ) {
     if num_columns >= 2 {
-        return unsafe { sse::butterfly_7_sse(data, stage_twiddles, 0, num_columns) };
+        return unsafe { sse::butterfly_7_sse2(data, stage_twiddles, 0, num_columns) };
     }
 
     butterfly_7_scalar(data, stage_twiddles, 0, num_columns);
@@ -405,17 +405,17 @@ mod tests {
     #[test]
     #[cfg(all(
         target_arch = "x86_64",
-        any(not(feature = "no_std"), target_feature = "sse")
+        any(not(feature = "no_std"), target_feature = "sse2")
     ))]
-    fn test_butterfly_7_sse_vs_scalar() {
+    fn test_butterfly_7_sse2_vs_scalar() {
         test_butterfly_against_scalar(
             |data, twiddles, num_columns| butterfly_7_scalar(data, twiddles, 0, num_columns),
             |data, twiddles, num_columns| unsafe {
-                sse::butterfly_7_sse(data, twiddles, 0, num_columns);
+                sse::butterfly_7_sse2(data, twiddles, 0, num_columns);
             },
             7,
             6,
-            "butterfly_7_sse",
+            "butterfly_7_sse2",
         );
     }
 

--- a/src/fft/butterflies/butterfly7/sse.rs
+++ b/src/fft/butterflies/butterfly7/sse.rs
@@ -1,14 +1,14 @@
-#[cfg(any(not(feature = "no_std"), target_feature = "sse"))]
+#[cfg(any(not(feature = "no_std"), target_feature = "sse2"))]
 use crate::Complex32;
 
-/// Pure SSE implementation: processes 2 columns at once.
+/// Pure SSE2 implementation: processes 2 columns at once.
 #[cfg(any(
     test,
     not(feature = "no_std"),
-    all(target_feature = "sse", not(target_feature = "sse3"))
+    all(target_feature = "sse2", not(target_feature = "sse3"))
 ))]
-#[target_feature(enable = "sse")]
-pub(super) unsafe fn butterfly_7_sse(
+#[target_feature(enable = "sse2")]
+pub(super) unsafe fn butterfly_7_sse2(
     data: &mut [Complex32],
     stage_twiddles: &[Complex32],
     start_col: usize,

--- a/src/fft/cooley_tukey_radix2.rs
+++ b/src/fft/cooley_tukey_radix2.rs
@@ -107,7 +107,7 @@ define_cooley_tukey_radix2!(
     cfg = all(target_arch = "x86_64", not(feature = "no_std"))
 );
 define_cooley_tukey_radix2!(
-    cooley_tukey_radix_2_sse,
-    butterfly_2_dispatch_sse,
+    cooley_tukey_radix_2_sse2,
+    butterfly_2_dispatch_sse2,
     cfg = all(target_arch = "x86_64", not(feature = "no_std"))
 );

--- a/src/fft/cooley_tukey_radixn.rs
+++ b/src/fft/cooley_tukey_radixn.rs
@@ -165,11 +165,11 @@ define_cooley_tukey_radixn!(
     cfg = all(target_arch = "x86_64", not(feature = "no_std"))
 );
 define_cooley_tukey_radixn!(
-    cooley_tukey_radix_n_sse,
-    butterfly_2_dispatch_sse,
-    butterfly_3_dispatch_sse,
-    butterfly_4_dispatch_sse,
-    butterfly_5_dispatch_sse,
-    butterfly_7_dispatch_sse,
+    cooley_tukey_radix_n_sse2,
+    butterfly_2_dispatch_sse2,
+    butterfly_3_dispatch_sse2,
+    butterfly_4_dispatch_sse2,
+    butterfly_5_dispatch_sse2,
+    butterfly_7_dispatch_sse2,
     cfg = all(target_arch = "x86_64", not(feature = "no_std"))
 );

--- a/src/fft/radix_fft.rs
+++ b/src/fft/radix_fft.rs
@@ -141,10 +141,10 @@ impl<D> RadixFFT<D> {
                 super::cooley_tukey_radix2::cooley_tukey_radix_2_sse3,
                 super::cooley_tukey_radixn::cooley_tukey_radix_n_sse3,
             )
-        } else if std::arch::is_x86_feature_detected!("sse") {
+        } else if std::arch::is_x86_feature_detected!("sse2") {
             (
-                super::cooley_tukey_radix2::cooley_tukey_radix_2_sse,
-                super::cooley_tukey_radixn::cooley_tukey_radix_n_sse,
+                super::cooley_tukey_radix2::cooley_tukey_radix_2_sse2,
+                super::cooley_tukey_radixn::cooley_tukey_radix_n_sse2,
             )
         } else {
             (


### PR DESCRIPTION
Internally butterflies were marked as x86_64 SSE even thought they used SSE2 functionality. This is now fixed. Since  all x86_64 need to support both SSE and SSE2 this is a theoretical problem, but which should be fixed.