### PR TITLE
Remove modulo bottleneck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2025-11-08
+
+### Changed
+
+- Improved performance for `ResamplerFft` by optimizing away a bottleneck caused by a modulo operation
+  (15% to 25% improved throughout).
+
 ## [0.3.4] - 2025-11-07
 
 ### Changed
 
-- Improved performance for `ResamplerFft` by internal optimizations (~10% improvement throughout).
+- Improved performance for `ResamplerFft` by internal optimizations (~10% improved throughout).
 
 ## [0.3.3] - 2025-11-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,18 +235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,12 +287,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "libc"
-version = "0.2.177"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libm"
@@ -398,28 +380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand_aes"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b5bbffc38dfb841ec07fd5c8aaf30154c0126bcb6c564b71f5ccc14629c976"
-dependencies = [
- "getrandom",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-
-[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,11 +439,10 @@ dependencies = [
 
 [[package]]
 name = "resampler"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "criterion",
  "libm",
- "rand_aes",
 ]
 
 [[package]]
@@ -597,15 +556,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen",
 ]
 
 [[package]]
@@ -774,12 +724,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "resampler"
 description = "A small audio resampling library"
 authors = ["Nils Hasenbanck <nils@hasenbanck.de>"]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -19,7 +19,6 @@ libm = { version = "0.2", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.7", features = ["html_reports"] }
-rand_aes = "0.5"
 
 [[bench]]
 name = "benchmark_resampler_fft"

--- a/benches/benchmark_resampler_fft.rs
+++ b/benches/benchmark_resampler_fft.rs
@@ -1,7 +1,6 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand_aes::tls::rand_f32;
 use resampler::{ResamplerFft, SampleRate};
 
 struct BenchmarkConfig {
@@ -11,7 +10,14 @@ struct BenchmarkConfig {
 }
 
 fn generate_white_noise(size: usize) -> Vec<f32> {
-    (0..size).map(|_| rand_f32()).collect()
+    let mut state: u128 = 456423156461231;
+    (0..size)
+        .map(|_| {
+            state = state.wrapping_mul(0xDA942042E4DD58B5);
+            let val = (state >> 64) as u64;
+            (val as f64 / u64::MAX as f64) as f32 * 2.0 - 1.0
+        })
+        .collect()
 }
 
 fn bench_resampler(c: &mut Criterion) {

--- a/benches/benchmark_resampler_fir.rs
+++ b/benches/benchmark_resampler_fir.rs
@@ -1,7 +1,6 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand_aes::tls::rand_f32;
 use resampler::{Attenuation, Latency, ResamplerFir, SampleRate};
 
 struct BenchmarkConfig {
@@ -11,7 +10,14 @@ struct BenchmarkConfig {
 }
 
 fn generate_white_noise(size: usize) -> Vec<f32> {
-    (0..size).map(|_| rand_f32()).collect()
+    let mut state: u128 = 456423156461231;
+    (0..size)
+        .map(|_| {
+            state = state.wrapping_mul(0xDA942042E4DD58B5);
+            let val = (state >> 64) as u64;
+            (val as f64 / u64::MAX as f64) as f32 * 2.0 - 1.0
+        })
+        .collect()
 }
 
 fn bench_resampler_fir(c: &mut Criterion) {

--- a/src/fft/butterflies/butterfly2/neon.rs
+++ b/src/fft/butterflies/butterfly2/neon.rs
@@ -80,14 +80,20 @@ pub(super) unsafe fn butterfly_radix2_generic_neon(
     stage_twiddles: &[Complex32],
     stride: usize,
 ) {
+    // We convince the compiler here that stride can't be 0 to optimize better.
+    if stride == 0 {
+        return;
+    }
+
     let samples = src.len();
     let half_samples = samples >> 1;
     let simd_iters = (half_samples >> 1) << 1;
 
     unsafe {
         for i in (0..simd_iters).step_by(2) {
-            let k0 = i % stride;
-            let k1 = (i + 1) % stride;
+            let k = i % stride;
+            let k0 = k;
+            let k1 = k + 1 - ((k + 1 >= stride) as usize) * stride;
 
             // Load 2 complex numbers from first half.
             let a_ptr = src.as_ptr().add(i) as *const f32;

--- a/src/fft/butterflies/butterfly2/sse2.rs
+++ b/src/fft/butterflies/butterfly2/sse2.rs
@@ -1,3 +1,5 @@
+use core::arch::x86_64::*;
+
 use crate::fft::{Complex32, butterflies::ops::complex_mul_sse2};
 
 /// Performs a single radix-2 Stockham butterfly stage for stride=1 (out-of-place, SSE2).
@@ -11,8 +13,6 @@ pub(super) unsafe fn butterfly_radix2_stride1_sse2(
     dst: &mut [Complex32],
     stage_twiddles: &[Complex32],
 ) {
-    use core::arch::x86_64::*;
-
     let samples = src.len();
     let half_samples = samples >> 1;
     let simd_iters = (half_samples >> 1) << 1;
@@ -76,7 +76,10 @@ pub(super) unsafe fn butterfly_radix2_generic_sse2(
     stage_twiddles: &[Complex32],
     stride: usize,
 ) {
-    use core::arch::x86_64::*;
+    // We convince the compiler here that stride can't be 0 to optimize better.
+    if stride == 0 {
+        return;
+    }
 
     let samples = src.len();
     let half_samples = samples >> 1;
@@ -84,8 +87,9 @@ pub(super) unsafe fn butterfly_radix2_generic_sse2(
 
     unsafe {
         for i in (0..simd_iters).step_by(2) {
-            let k0 = i % stride;
-            let k1 = (i + 1) % stride;
+            let k = i % stride;
+            let k0 = k;
+            let k1 = k + 1 - ((k + 1 >= stride) as usize) * stride;
 
             // Load 2 complex numbers from first half.
             let a_ptr = src.as_ptr().add(i) as *const f32;

--- a/src/fft/butterflies/butterfly3/sse4_2.rs
+++ b/src/fft/butterflies/butterfly3/sse4_2.rs
@@ -128,8 +128,9 @@ pub(super) unsafe fn butterfly_radix3_generic_sse4_2(
         let half_vec = _mm_set1_ps(0.5);
 
         for i in (0..simd_iters).step_by(2) {
-            let k0 = i % stride;
-            let k1 = (i + 1) % stride;
+            let k = i % stride;
+            let k0 = k;
+            let k1 = k + 1 - ((k + 1 >= stride) as usize) * stride;
 
             // Load 2 complex numbers from each third.
             let z0_ptr = src.as_ptr().add(i) as *const f32;

--- a/src/fft/butterflies/butterfly4/avx.rs
+++ b/src/fft/butterflies/butterfly4/avx.rs
@@ -1,3 +1,5 @@
+use core::arch::x86_64::*;
+
 use crate::fft::{
     Complex32,
     butterflies::ops::{complex_mul_avx, complex_mul_i_avx, load_neg_imag_mask_avx},
@@ -13,8 +15,6 @@ pub(super) unsafe fn butterfly_radix4_stride1_avx_fma(
     dst: &mut [Complex32],
     stage_twiddles: &[Complex32],
 ) {
-    use core::arch::x86_64::*;
-
     let samples = src.len();
     let quarter_samples = samples >> 2;
     let simd_iters = (quarter_samples >> 2) << 2;
@@ -131,7 +131,10 @@ pub(super) unsafe fn butterfly_radix4_generic_avx_fma(
     stage_twiddles: &[Complex32],
     stride: usize,
 ) {
-    use core::arch::x86_64::*;
+    // We convince the compiler here that stride can't be 0 to optimize better.
+    if stride == 0 {
+        return;
+    }
 
     let samples = src.len();
     let quarter_samples = samples >> 2;
@@ -141,11 +144,11 @@ pub(super) unsafe fn butterfly_radix4_generic_avx_fma(
         let neg_imag_mask = load_neg_imag_mask_avx();
 
         for i in (0..simd_iters).step_by(4) {
-            // Calculate twiddle indices.
-            let k0 = i % stride;
-            let k1 = (i + 1) % stride;
-            let k2 = (i + 2) % stride;
-            let k3 = (i + 3) % stride;
+            let k = i % stride;
+            let k0 = k;
+            let k1 = k + 1 - ((k + 1 >= stride) as usize) * stride;
+            let k2 = k + 2 - ((k + 2 >= stride) as usize) * stride;
+            let k3 = k + 3 - ((k + 3 >= stride) as usize) * stride;
 
             // Load z0 from first quarter.
             let z0_ptr = src.as_ptr().add(i) as *const f32;

--- a/src/fft/butterflies/butterfly4/sse2.rs
+++ b/src/fft/butterflies/butterfly4/sse2.rs
@@ -1,3 +1,5 @@
+use core::arch::x86_64::*;
+
 use crate::fft::{
     Complex32,
     butterflies::ops::{complex_mul_i_sse2, complex_mul_sse2, load_neg_imag_mask_sse2},
@@ -13,8 +15,6 @@ pub(super) unsafe fn butterfly_radix4_stride1_sse2(
     dst: &mut [Complex32],
     stage_twiddles: &[Complex32],
 ) {
-    use core::arch::x86_64::*;
-
     let samples = src.len();
     let quarter_samples = samples >> 2;
     let simd_iters = (quarter_samples >> 1) << 1;
@@ -125,7 +125,10 @@ pub(super) unsafe fn butterfly_radix4_generic_sse2(
     stage_twiddles: &[Complex32],
     stride: usize,
 ) {
-    use core::arch::x86_64::*;
+    // We convince the compiler here that stride can't be 0 to optimize better.
+    if stride == 0 {
+        return;
+    }
 
     let samples = src.len();
     let quarter_samples = samples >> 2;
@@ -135,9 +138,9 @@ pub(super) unsafe fn butterfly_radix4_generic_sse2(
         let neg_imag_mask = load_neg_imag_mask_sse2();
 
         for i in (0..simd_iters).step_by(2) {
-            // Calculate twiddle indices.
-            let k0 = i % stride;
-            let k1 = (i + 1) % stride;
+            let k = i % stride;
+            let k0 = k;
+            let k1 = k + 1 - ((k + 1 >= stride) as usize) * stride;
 
             // Load z0 from first quarter.
             let z0_ptr = src.as_ptr().add(i) as *const f32;

--- a/src/fft/butterflies/butterfly5/sse4_2.rs
+++ b/src/fft/butterflies/butterfly5/sse4_2.rs
@@ -1,3 +1,5 @@
+use core::arch::x86_64::*;
+
 use super::{COS_2PI_5, COS_4PI_5, SIN_2PI_5, SIN_4PI_5};
 use crate::fft::{
     Complex32,
@@ -14,8 +16,6 @@ pub(super) unsafe fn butterfly_radix5_stride1_sse4_2(
     dst: &mut [Complex32],
     stage_twiddles: &[Complex32],
 ) {
-    use core::arch::x86_64::*;
-
     let samples = src.len();
     let fifth_samples = samples / 5;
     let simd_iters = (fifth_samples >> 1) << 1;
@@ -200,7 +200,10 @@ pub(super) unsafe fn butterfly_radix5_generic_sse4_2(
     stage_twiddles: &[Complex32],
     stride: usize,
 ) {
-    use core::arch::x86_64::*;
+    // We convince the compiler here that stride can't be 0 to optimize better.
+    if stride == 0 {
+        return;
+    }
 
     let samples = src.len();
     let fifth_samples = samples / 5;
@@ -215,8 +218,9 @@ pub(super) unsafe fn butterfly_radix5_generic_sse4_2(
         let negate_im = load_neg_imag_mask_sse4_2();
 
         for i in (0..simd_iters).step_by(2) {
-            let k0 = i % stride;
-            let k1 = (i + 1) % stride;
+            let k = i % stride;
+            let k0 = k;
+            let k1 = k + 1 - ((k + 1 >= stride) as usize) * stride;
 
             // Load 2 complex numbers from each fifth.
             let z0_ptr = src.as_ptr().add(i) as *const f32;

--- a/src/fft/butterflies/butterfly7/sse2.rs
+++ b/src/fft/butterflies/butterfly7/sse2.rs
@@ -1,3 +1,5 @@
+use core::arch::x86_64::*;
+
 use super::{COS_2PI_7, COS_4PI_7, COS_6PI_7, SIN_2PI_7, SIN_4PI_7, SIN_6PI_7};
 use crate::fft::{
     Complex32,
@@ -14,8 +16,6 @@ pub(super) unsafe fn butterfly_radix7_stride1_sse2(
     dst: &mut [Complex32],
     stage_twiddles: &[Complex32],
 ) {
-    use core::arch::x86_64::*;
-
     let samples = src.len();
     let seventh_samples = samples / 7;
     let simd_iters = (seventh_samples >> 1) << 1;
@@ -27,6 +27,10 @@ pub(super) unsafe fn butterfly_radix7_stride1_sse2(
         let sin_4pi_7 = _mm_set1_ps(SIN_4PI_7);
         let cos_6pi_7 = _mm_set1_ps(COS_6PI_7);
         let sin_6pi_7 = _mm_set1_ps(SIN_6PI_7);
+
+        let neg_sin_6pi_7 = _mm_set1_ps(-SIN_6PI_7);
+        let neg_sin_2pi_7 = _mm_set1_ps(-SIN_2PI_7);
+        let neg_sin_4pi_7 = _mm_set1_ps(-SIN_4PI_7);
 
         let negate_im = load_neg_imag_mask_sse2();
 
@@ -121,8 +125,6 @@ pub(super) unsafe fn butterfly_radix7_stride1_sse2(
             let out1 = _mm_add_ps(c1, d1);
 
             // out2: cos1=COS_4PI_7, sin1=SIN_4PI_7, cos2=COS_6PI_7, sin2=-SIN_6PI_7, cos3=COS_2PI_7, sin3=-SIN_2PI_7
-            let neg_sin_6pi_7 = _mm_set1_ps(-SIN_6PI_7);
-            let neg_sin_2pi_7 = _mm_set1_ps(-SIN_2PI_7);
             let c2 = _mm_add_ps(
                 z0,
                 _mm_add_ps(
@@ -151,7 +153,6 @@ pub(super) unsafe fn butterfly_radix7_stride1_sse2(
             let out3 = _mm_add_ps(c3, d3);
 
             // out4: cos1=COS_6PI_7, sin1=-SIN_6PI_7, cos2=COS_2PI_7, sin2=SIN_2PI_7, cos3=COS_4PI_7, sin3=-SIN_4PI_7
-            let neg_sin_4pi_7 = _mm_set1_ps(-SIN_4PI_7);
             let c4 = _mm_add_ps(
                 z0,
                 _mm_add_ps(
@@ -308,7 +309,10 @@ pub(super) unsafe fn butterfly_radix7_generic_sse2(
     stage_twiddles: &[Complex32],
     stride: usize,
 ) {
-    use core::arch::x86_64::*;
+    // We convince the compiler here that stride can't be 0 to optimize better.
+    if stride == 0 {
+        return;
+    }
 
     let samples = src.len();
     let seventh_samples = samples / 7;
@@ -322,11 +326,16 @@ pub(super) unsafe fn butterfly_radix7_generic_sse2(
         let cos_6pi_7 = _mm_set1_ps(COS_6PI_7);
         let sin_6pi_7 = _mm_set1_ps(SIN_6PI_7);
 
+        let neg_sin_6pi_7 = _mm_set1_ps(-SIN_6PI_7);
+        let neg_sin_2pi_7 = _mm_set1_ps(-SIN_2PI_7);
+        let neg_sin_4pi_7 = _mm_set1_ps(-SIN_4PI_7);
+
         let negate_im = load_neg_imag_mask_sse2();
 
         for i in (0..simd_iters).step_by(2) {
-            let k0 = i % stride;
-            let k1 = (i + 1) % stride;
+            let k = i % stride;
+            let k0 = k;
+            let k1 = k + 1 - ((k + 1 >= stride) as usize) * stride;
 
             // Load 2 complex numbers from each seventh.
             let z0_ptr = src.as_ptr().add(i) as *const f32;
@@ -393,11 +402,6 @@ pub(super) unsafe fn butterfly_radix7_generic_sse2(
             let b3 = _mm_xor_ps(b3_temp, negate_im);
 
             let out0 = _mm_add_ps(z0, sum_all);
-
-            // Compute outputs 1-6
-            let neg_sin_6pi_7 = _mm_set1_ps(-SIN_6PI_7);
-            let neg_sin_2pi_7 = _mm_set1_ps(-SIN_2PI_7);
-            let neg_sin_4pi_7 = _mm_set1_ps(-SIN_4PI_7);
 
             let c1 = _mm_add_ps(
                 z0,

--- a/src/fft/butterflies/ops/avx.rs
+++ b/src/fft/butterflies/ops/avx.rs
@@ -28,12 +28,7 @@ pub(crate) fn complex_mul_i_avx(vec: __m256, neg_imag_mask: __m256) -> __m256 {
 
 /// Multiplies a complex vector by sqrt(3)/2 * i.
 #[target_feature(enable = "avx")]
-pub(crate) fn complex_mul_sqrt3_i_avx(vec: __m256, sqrt3_2: f32) -> __m256 {
+pub(crate) fn complex_mul_sqrt3_i_avx(vec: __m256, sqrt3_pattern: __m256) -> __m256 {
     let swapped = _mm256_shuffle_ps(vec, vec, 0b10_11_00_01);
-    _mm256_mul_ps(
-        swapped,
-        _mm256_set_ps(
-            -sqrt3_2, sqrt3_2, -sqrt3_2, sqrt3_2, -sqrt3_2, sqrt3_2, -sqrt3_2, sqrt3_2,
-        ),
-    )
+    _mm256_mul_ps(swapped, sqrt3_pattern)
 }


### PR DESCRIPTION
We only calculate modulo once and after that only use branchless operations.

This improves throughput for AVX by 17 to 25%!